### PR TITLE
Temporary RPC switch

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -22,7 +22,7 @@ export function createProduction (t: TFunction, firstOnly: boolean, withSort: bo
       info: 'edgeware',
       text: t('rpc.prod.edgeware', 'Edgeware', { ns: 'apps-config' }),
       providers: {
-        'Commonwealth Labs': 'wss://mainnet.edgewa.re',
+        'Commonwealth Labs': 'wss://mainnet3.edgewa.re',
         OnFinality: 'wss://edgeware.api.onfinality.io/public-ws',
         Dwellir: 'wss://edgeware-rpc.dwellir.com'
       }


### PR DESCRIPTION
Changing the CW's endpoint from load-balancer to a solo node temporarily until the load-balancer gets fixed.